### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Open and run the DGElasticPullToRefreshExample project in Xcode to see DGElastic
 
 ## Installation
 
-### Cocoapods
+### CocoaPods
 
 ``` ruby
 pod "DGElasticPullToRefresh"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Remove pull to refresh:
 func dg_removePullToRefresh()
 ```
 
+Set auto start loading:
+
+``` swift
+func dg_startLoading()
+```
+
 Change pull to refresh background color:
 
 ``` swift


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
